### PR TITLE
Cast the revisionable_id to string to support string ids

### DIFF
--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -24,6 +24,13 @@ class Revision extends Eloquent
     /**
      * @var array
      */
+    protected $casts = array(
+        'revisionable_id' => 'string'
+    );
+
+    /**
+     * @var array
+     */
     protected $revisionFormattedFields = array();
 
     /**


### PR DESCRIPTION
Cast the revisionable_id to string to support string ids such as UUIDs and ULIDs.